### PR TITLE
Adds support to specify a Riak host

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ are as follows:
 
     import riak
     RIAK_PORT = 8087
+    fIAK_HOST = '127.0.0.1'
     RIAK_TRANSPORT_CLASS = riak.RiakPbcTransport
     RIAK_BUCKET = 'django-riak-sessions'
     RIAK_SESSION_KEY = 'session:%(session_key)s'

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ values are as follows:
 
     import riak
     RIAK_PORT = 8087
+    RIAK_HOST = '127.0.0.1'
     RIAK_TRANSPORT_CLASS = riak.RiakPbcTransport
     RIAK_BUCKET = 'django-riak-sessions'
     RIAK_SESSION_KEY = 'session:%(session_key)s'

--- a/riak_sessions/__init__.py
+++ b/riak_sessions/__init__.py
@@ -4,7 +4,7 @@ from django.conf import settings
 RIAK_PORT = getattr(settings, 'RIAK_PORT', 8087)
 RIAK_TRANSPORT_CLASS = getattr(settings, 'RIAK_TRANSPORT_CLASS', riak.RiakPbcTransport)
 RIAK_BUCKET = getattr(settings, 'RIAK_BUCKET', 'django-riak-sessions')
+RIAK_HOST = getattr(settings, 'RIAK_HOST', '127.0.0.1')
 
-
-client = riak.RiakClient(port = RIAK_PORT, transport_class = RIAK_TRANSPORT_CLASS)
+client = riak.RiakClient(port = RIAK_PORT, host=RIAK_HOST, transport_class = RIAK_TRANSPORT_CLASS)
 bucket = client.bucket(RIAK_BUCKET)


### PR DESCRIPTION
RIAK_HOST can be set to specify the session storage host.
