### PR TITLE
Hey, this is a fix for differing key names being used in the session store.

### DIFF
--- a/riak_sessions/backends/riak.py
+++ b/riak_sessions/backends/riak.py
@@ -65,10 +65,10 @@ class SessionStore(SessionBase):
             session_data = session.get_data()
 
             # only return unexpired sessions
-            expire_date = datetime.fromtimestamp(session_data['_expire_date'])
+            expire_date = datetime.fromtimestamp(session_data['expire'])
             now = datetime.now()
             if (now - expire_date) < timedelta(seconds=settings.SESSION_COOKIE_AGE):
-                decoded = self.decode(session_data['_encoded_data'])
+                decoded = self.decode(session_data['data'])
                 return decoded
 
         self.create()


### PR DESCRIPTION
Inexplicably, the current code uses different keys for setting/reading from the Riak objects. I fixed that, here.

(Also, we're having some issues where sessions are dropped, not sure if you ran into something similar to that. When I figure out what it is, I'll send another pull request.)

Dan
